### PR TITLE
alternative approach to removing ServerOptionsBuilderOptions

### DIFF
--- a/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/CertificateStore.cs
+++ b/src/Microsoft.Azure.Batch.SoftwareEntitlement.Common/CertificateStore.cs
@@ -6,10 +6,17 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Common
 {
+    public interface ICertificateStore
+    {
+        IEnumerable<X509Certificate2> FindAll();
+
+        Errorable<X509Certificate2> FindByThumbprint(string purpose, CertificateThumbprint thumbprint);
+    }
+
     /// <summary>
     /// A simple abstraction over the framework supplied store classes
     /// </summary>
-    public sealed class CertificateStore
+    public sealed class CertificateStore : ICertificateStore
     {
         // A list of StoreNames where we should look when finding certificates
         private readonly List<StoreName> _storeNames;

--- a/src/sestest/Program.cs
+++ b/src/sestest/Program.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         // Provider used for ASP.NET logging
         private static ILoggerProvider _provider;
 
+        private static ICertificateStore _certificateStore = new CertificateStore();
+
         public static async Task<int> Main(string[] args)
         {
             var parser = new Parser(ConfigureParser);
@@ -67,7 +69,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement
         /// <returns>Exit code to return from this process.</returns>
         public static async Task<int> Serve(ServerCommandLine commandLine)
         {
-            var options = ServerOptionBuilder.Build(commandLine);
+            var options = ServerOptionBuilder.Build(commandLine, _certificateStore);
             return await options.Match(
                 RunServer,
                 errors =>

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/FakeCertificateStore.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/FakeCertificateStore.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
+
+namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
+{
+    public class FakeCertificateStore : ICertificateStore
+    {
+        private readonly string _notFoundError;
+        private readonly Dictionary<string, X509Certificate2> _certLookup;
+
+        public FakeCertificateStore(
+            string notFoundError,
+            params (CertificateThumbprint Thumbprint, X509Certificate2 Certificate)[] certificates)
+        {
+            _notFoundError = notFoundError;
+            _certLookup = certificates.ToDictionary(pair => pair.Thumbprint.ToString(), pair => pair.Certificate);
+        }
+
+        public IEnumerable<X509Certificate2> FindAll()
+        {
+            return _certLookup.Values;
+        }
+
+        public Errorable<X509Certificate2> FindByThumbprint(string purpose, CertificateThumbprint thumbprint)
+        {
+            return _certLookup.ContainsKey(thumbprint.ToString())
+                ? Errorable.Success(_certLookup[thumbprint.ToString()])
+                : Errorable.Failure<X509Certificate2>(_notFoundError);
+        }
+    }
+}

--- a/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
+++ b/tests/Microsoft.Azure.Batch.SoftwareEntitlement.Tests/ServerOptionBuilderTests.cs
@@ -1,4 +1,6 @@
+using System.Security.Cryptography.X509Certificates;
 using FluentAssertions;
+using Microsoft.Azure.Batch.SoftwareEntitlement.Common;
 using Xunit;
 
 namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
@@ -9,24 +11,20 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
     /// </summary>
     public class ServerOptionBuilderTests
     {
-        // One thumbprint string to use for testing
-        private readonly string _thumbprint = "1S TR UL EO FC ER TC LU BI SD ON TT AL KA BO UT CE RT CL UB";
+        private static readonly CertificateThumbprint ConnectionCertificateThumbprint
+            = new CertificateThumbprint("1S TR UL EO FC ER TC LU BI SD ON TT AL KA BO UT CE RT CL UB");
 
-        // Server options for testing
-        private readonly ServerCommandLine _commandLine = new ServerCommandLine();
+        // A valid set of command line arguments for testing
+        private readonly ServerCommandLine _commandLine = new ServerCommandLine
+        {
+            ConnectionCertificateThumbprint = ConnectionCertificateThumbprint.ToString()
+        };
 
-        // Building a ServerOptions object consists of two actions for each property:
-        // 1. Validating/parsing/defaulting the user input; and
-        // 2. Initializing a copy of the ServerOptions object with the appropriate
-        //    property value set.
-        // To ensure the second part is not missed, we're unit testing both of these
-        // actions together. We want to test each property individually, but some
-        // properties are intended to be mandatory, and their absence will cause
-        // errors unrelated to the property being tested. To work around this we use
-        // a "permissive" option which changes the behaviour of the builder such that
-        // the enforcement of mandatory properties is bypassed.
-        private readonly ServerOptionBuilderOptions _permissiveOptions =
-            ServerOptionBuilderOptions.ConnectionThumbprintOptional;
+        private const string CertificateNotFoundError = "Certificate not found test error";
+
+        private readonly ICertificateStore _certificateStoreWithConnectionCertificate = new FakeCertificateStore(
+            CertificateNotFoundError,
+            (ConnectionCertificateThumbprint, new X509Certificate2()));
 
         public class ServerUrl : ServerOptionBuilderTests
         {
@@ -34,7 +32,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithEmptyServerUrl_SetsDefaultServerUrl()
             {
                 _commandLine.ServerUrl = string.Empty;
-                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                var options = ServerOptionBuilder.Build(_commandLine, _certificateStoreWithConnectionCertificate);
                 options.Value.ServerUrl.Should().Be(ServerCommandLine.DefaultServerUrl);
             }
 
@@ -42,7 +40,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithHttpServerUrl_HasErrorForServerUrl()
             {
                 _commandLine.ServerUrl = "http://www.example.com";
-                var options = ServerOptionBuilder.Build(_commandLine);
+                var options = ServerOptionBuilder.Build(_commandLine, _certificateStoreWithConnectionCertificate);
                 options.Errors.Should().Contain(e => e.Contains("Server endpoint URL"));
             }
 
@@ -50,7 +48,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void WithValidServerUrl_ConfigureServerUrl()
             {
                 _commandLine.ServerUrl = "https://example.com/";
-                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                var options = ServerOptionBuilder.Build(_commandLine, _certificateStoreWithConnectionCertificate);
                 options.Value.ServerUrl.ToString().Should().Be(_commandLine.ServerUrl);
             }
         }
@@ -61,7 +59,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithNoConnectionThumbprint_DoesNotReturnValue()
             {
                 _commandLine.ConnectionCertificateThumbprint = string.Empty;
-                var options = ServerOptionBuilder.Build(_commandLine);
+                var options = ServerOptionBuilder.Build(_commandLine, _certificateStoreWithConnectionCertificate);
                 options.HasValue.Should().BeFalse();
             }
 
@@ -69,16 +67,16 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithNoConnectionThumbprint_HasErrorForConnection()
             {
                 _commandLine.ConnectionCertificateThumbprint = string.Empty;
-                var options = ServerOptionBuilder.Build(_commandLine);
+                var options = ServerOptionBuilder.Build(_commandLine, _certificateStoreWithConnectionCertificate);
                 options.Errors.Should().Contain(e => e.Contains("connection"));
             }
 
             [Fact]
             public void Build_WithUnknownConnectionThumbprint_HasErrorForConnection()
             {
-                _commandLine.ConnectionCertificateThumbprint = _thumbprint;
-                var options = ServerOptionBuilder.Build(_commandLine);
-                options.Errors.Should().Contain(e => e.Contains("connection"));
+                _commandLine.ConnectionCertificateThumbprint = "2N DR UL EO FC ER TC LU BI SD ON TT AL KA BO UT CE RT CL UB";
+                var options = ServerOptionBuilder.Build(_commandLine, _certificateStoreWithConnectionCertificate);
+                options.Errors.Should().Contain(CertificateNotFoundError);
             }
         }
 
@@ -88,7 +86,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithEmptyAudience_HasDefaultValueForAudience()
             {
                 _commandLine.Audience = string.Empty;
-                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                var options = ServerOptionBuilder.Build(_commandLine, _certificateStoreWithConnectionCertificate);
                 options.Value.Audience.Should().NotBeNullOrEmpty();
             }
         }
@@ -99,7 +97,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithEmptyIssuer_HasDefaultValueForIssuer()
             {
                 _commandLine.Issuer = string.Empty;
-                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                var options = ServerOptionBuilder.Build(_commandLine, _certificateStoreWithConnectionCertificate);
                 options.Value.Issuer.Should().NotBeNullOrEmpty();
             }
         }
@@ -110,7 +108,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithoutExitAfterRequest_ShouldHaveDefault()
             {
                 _commandLine.ExitAfterRequest = false;
-                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                var options = ServerOptionBuilder.Build(_commandLine, _certificateStoreWithConnectionCertificate);
                 options.Value.ExitAfterRequest.Should().BeFalse();
             }
 
@@ -118,7 +116,7 @@ namespace Microsoft.Azure.Batch.SoftwareEntitlement.Tests
             public void Build_WithExitAfterRequest_ConfiguresValue()
             {
                 _commandLine.ExitAfterRequest = true;
-                var options = ServerOptionBuilder.Build(_commandLine, _permissiveOptions);
+                var options = ServerOptionBuilder.Build(_commandLine, _certificateStoreWithConnectionCertificate);
                 options.Value.ExitAfterRequest.Should().BeTrue();
             }
         }


### PR DESCRIPTION
Rather than changing the behaviour of the builder itself, I wanted to see if we can change the CertificateStore implementation so that it doesn't block testing.